### PR TITLE
Better project name guessing

### DIFF
--- a/DiscordRichPresence.sublime-settings
+++ b/DiscordRichPresence.sublime-settings
@@ -35,6 +35,6 @@
     //
     //   "project_file_name" - The name of the .sublime-project file.
     //   "project_folder_name" - The name of the folder in the project that the file being edited resides in.
-    //   "folder_name" - The name of the folder containing the file being edited.
+    //   "folder_name" - The name of the folder containing the file being edited, or the parent folder (when the folder name is 'src').
     "project_name": ["project_file_name", "project_folder_name", "folder_name"]
 }

--- a/drp.py
+++ b/drp.py
@@ -154,6 +154,11 @@ def get_project_name(window, current_file):
                 return os.path.basename(os.path.dirname(current_file))
         elif source == "folder_name":
             return os.path.basename(os.path.dirname(current_file))
+        elif source == "folder_name_ignore_srcdir":
+            if os.path.basename(os.path.dirname(current_file)) == "src":
+                return os.path.basename(os.path.abspath(os.path.join(os.path.dirname(current_file), os.pardir)))
+            else:
+                return os.path.basename(os.path.dirname(current_file))
         else:
             logger.error("Unknown source for `project_name` setting: %r", source)
 

--- a/drp.py
+++ b/drp.py
@@ -153,8 +153,6 @@ def get_project_name(window, current_file):
             if project_file_path:
                 return os.path.basename(os.path.dirname(current_file))
         elif source == "folder_name":
-            return os.path.basename(os.path.dirname(current_file))
-        elif source == "folder_name_ignore_srcdir":
             if os.path.basename(os.path.dirname(current_file)) == "src":
                 return os.path.basename(os.path.abspath(os.path.join(os.path.dirname(current_file), os.pardir)))
             else:


### PR DESCRIPTION
Adds option `folder_name_ignore_srcdir`

Uses parent dir name when:
- `project_name` has `folder_name_ignore_srcdir` instead of `folder_name`
- the folder name is `src` (indicating the parent dir most likely holds the project name)

Behaves like `folder_name` otherwise.