### PR TITLE
Add config switch to set language icon as big one

### DIFF
--- a/DiscordRichPresence.sublime-settings
+++ b/DiscordRichPresence.sublime-settings
@@ -29,7 +29,10 @@
     "send_start_timestamp": true,
 
     // Whether or not to use the small icon (changes for every language) in the presence.
-    "small_icon" : true,
+    "small_icon": true,
+
+    // Use the language icon as the big icon, overrides 'small_icon'
+    "big_icon": false,
 
     // Defines the order of name sources that should be used for the project name in format stings, if available.
     //

--- a/drp.py
+++ b/drp.py
@@ -129,6 +129,11 @@ def handle_activity(view, is_write=False):
     if settings.get('small_icon'):
         act['assets']['small_image'] = get_icon(extension)
         act['assets']['small_text'] = language
+    elif settings.get('reverse_icons'):
+        act['assets']['small_image'] = act['assets']['large_image']
+        act['assets']['small_text'] = act['assets']['large_text']
+        act['assets']['large_image'] = get_icon(extension)
+        act['assets']['large_text'] = language
 
     try:
         ipc.set_activity(act)

--- a/drp.py
+++ b/drp.py
@@ -126,14 +126,14 @@ def handle_activity(view, is_write=False):
     if state_format:
         act['state'] = state_format.format(**format_dict)
 
-    if settings.get('small_icon'):
-        act['assets']['small_image'] = get_icon(extension)
-        act['assets']['small_text'] = language
-    elif settings.get('reverse_icons'):
+    if settings.get('big_icon'):
         act['assets']['small_image'] = act['assets']['large_image']
         act['assets']['small_text'] = act['assets']['large_text']
         act['assets']['large_image'] = get_icon(extension)
         act['assets']['large_text'] = language
+    elif settings.get('small_icon'):
+        act['assets']['small_image'] = get_icon(extension)
+        act['assets']['small_text'] = language
 
     try:
         ipc.set_activity(act)


### PR DESCRIPTION
Using this `big_icon` switch, users can choose to set the language icon as the big one in the rich presence modal.

This looks like this: 
![discordptb_2017-12-14_22-01-04](https://user-images.githubusercontent.com/8442384/34014147-689b4f9a-e11a-11e7-9367-6036e0a7d57f.png)