### PR TITLE
Fixed project_file_name

### DIFF
--- a/drp.py
+++ b/drp.py
@@ -151,7 +151,7 @@ def get_project_name(window, current_file):
         elif source == "project_file_name":
             project_file_path = window.project_file_name()
             if project_file_path:
-                return os.path.basename(os.path.dirname(current_file))
+                return '.'.join(os.path.splitext(os.path.basename(project_file_path))[:-1])
         elif source == "folder_name":
             return os.path.basename(os.path.dirname(current_file))
         else:


### PR DESCRIPTION
Hi,

The project_file_name wasn't retrieved properly, instead it was using the folder name of the current file.
I fixed it and it is now returning the .sublime-project file name without its extension.

Maybe there is a better way to get the current project name without relying directly on the .sublime-project file :
```py
var = sublime.active_window().extract_variables()
project = "Project Name"
if "project_base_name" in var:
    project = var['project_base_name']
```
In this snippet the project name is retrieved from the window variables. Not tested on ST2 though.