### PR TITLE
use scope to detect language

### DIFF
--- a/drp.py
+++ b/drp.py
@@ -73,10 +73,10 @@ def get_icon(main_scope):
     return 'lang-%s' % icon
 
 def yield_subscopes(scope):
-    while scope:
-        yield scope
-        dot_index = scope.rfind('.')
-        scope = None if dot_index < 0 else scope[:dot_index]
+    last_dot = len(scope)
+    while last_dot > 0:
+        yield scope[:last_dot]
+        last_dot = scope[:last_dot].rfind('.')
 
 def sizehf(num):
     for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:

--- a/drp.py
+++ b/drp.py
@@ -30,35 +30,46 @@ def base_activity():
         activity['timestamps'] = {'start': start_time}
     return activity
 
+# List of icon names that are also language names.
+AVAILABLES_ICONS = {
+    'c',
+    'crystal',
+    'cs',
+    'css',
+    'd',
+    'elixir',
+    'go',
+    'java',
+    'json',
+    'lua',
+    'php',
+    'python',
+    'ruby',
+    'html',
+}
+
+# Map a scope to a specific icon. The first token of the scope (source or text)
+# has been dropped.
 SCOPE_ICON_MAP = {
-    'source.c': 'c',
-    'source.c++': 'cpp',
-    'source.crystal': 'crystal',
-    'source.cs': 'cs',
-    'source.css': 'css',
-    'source.d': 'd',
-    'source.elixir': 'elixir',
-    'source.go': 'go',
-    'source.java': 'java',
-    'source.java-props': 'java',
-    'source.js': 'javascript',
-    'source.json': 'json',
-    'source.lua': 'lua',
-    'source.php': 'php',
-    'source.python': 'python',
-    'source.ruby': 'ruby',
-    'source.ts': 'typescript',
-    'text.html': 'html',
-    'text.html.markdown': 'markdown',
+    'c++': 'cpp',
+    'java-props': 'java',
+    'js': 'javascript',
+    'ts': 'typescript',
+    'html.markdown': 'markdown',
 }
 
 def get_icon(main_scope):
-    icon = 'unknown'
-    for scope in yield_subscopes(main_scope):
-        if scope in SCOPE_ICON_MAP:
-            icon = SCOPE_ICON_MAP.get(scope)
+    base_scope, sub_scope = main_scope.split('.', 1)
+    icon = 'text' if base_scope == 'text' else 'unknown'
+    for scope in yield_subscopes(sub_scope):
+        if scope in AVAILABLES_ICONS:
+            icon = scope
             break
-    logger.info('Using icon %s for scope %s', icon, main_scope)
+        elif scope in SCOPE_ICON_MAP:
+            icon = SCOPE_ICON_MAP[scope]
+            break
+
+    logger.info('Using icon "%s" for scope "%s"', icon, main_scope)
     return 'lang-%s' % icon
 
 def yield_subscopes(scope):


### PR DESCRIPTION
When choosing the icon for a given view,
I propose the following logic:

1. load the scope at position 0 of the view: `source.python meta.statement.import.python ...`
2. keep only the first part: `source.python`
3. look for the scope in the `SCOPE_ICON_MAP` dict
4. if nothing match, drop the last suffix (`source.python -> source`) and go to 3.

The matching by the more precise scope allows to map `text.html.markdown` to "markdown" while `text.html` are mapped to "html".
All Package Dev syntaxes are supported. The one using `source.json.sublime.something` will map to "json".

Note this PR will handle .csproj as XML files, since there is no special syntax for them. Is that  a problem ?

Style consideration: The code may look like a bit more complicated . Another possible implementation would make `SCOPE_ICON_MAP` a list and look for the first scope covering the received scope.
It would require maintaining a well sorted list of scope, and probably will be less efficient (not a big concern probably)