### PR TITLE
Added {loc} for lines of code!

### DIFF
--- a/DiscordRichPresence.sublime-settings
+++ b/DiscordRichPresence.sublime-settings
@@ -13,6 +13,7 @@
     //   {lang} - The language of the file (Ex. JavaScript)
     //   {size} - The size of the file
     //   {sizehf} - The human friendly size of the file
+    //   {loc} - The amount of lines of code of the file
     //   {project} - The project name (or folder name) that the file is contained in. See `project_name` setting.
     //   {folders} - The number of folders open
 

--- a/drp.py
+++ b/drp.py
@@ -114,6 +114,7 @@ def handle_activity(view, is_write=False):
         project=get_project_name(window, entity),
         size=view.size(),
         sizehf=sizehf(view.size()),
+        loc=view.rowcol(view.size())[0]+1,
         folders=len(window.folders()),
     )
     last_file = entity


### PR DESCRIPTION
I've been using `view.rowcol(view.size())[0]+1` for a while and I haven't had any performance issues with it. Seems absolutely fine... I would love to see this in the plugin instead of having to add it manually. ^^

Also, `//   {loc} - The amount of lines of code of the file`... I feel like I could have phrased that better but I don't really know.

Thanks!