### PR TITLE
Handle removing the sublime-text path from the end of XDG_RUNTIME_DIR…

### DIFF
--- a/discord_ipc/__init__.py
+++ b/discord_ipc/__init__.py
@@ -209,6 +209,8 @@ class UnixDiscordIpcClient(DiscordIpcClient):
         env_keys = ('XDG_RUNTIME_DIR', 'TMPDIR', 'TMP', 'TEMP')
         for env_key in env_keys:
             dir_path = os.environ.get(env_key)
+            if dir_path.endswith('snap.sublime-text'):
+                dir_path = dir_path[:-17]
             if dir_path:
                 break
         else:


### PR DESCRIPTION
… if both sublime and discord are snaps

This might just be a problem with ubuntu 18.04 and beyond, but this fixes it for me.