### PR TITLE
Added option to diable elapsed time

### DIFF
--- a/DiscordRichPresence.sublime-settings
+++ b/DiscordRichPresence.sublime-settings
@@ -32,6 +32,9 @@
     // Whether to change the timestamp when switching to/editing another file.
     "time_per_file": true,
 
+    // Whether or not to show the elapsed time
+    "show_elapsed_time": true,
+
     // Whether or not to use the small icon (changes for every language) in the presence.
     "small_icon": false,
 

--- a/drp.py
+++ b/drp.py
@@ -129,6 +129,7 @@ SCOPES = {
     'raku'
 }
 
+
 def get_icon(file, ext, _scope):
     main_scope = _scope.split()[0]
     base_scope = main_scope.split('.')[0]
@@ -153,6 +154,7 @@ def get_icon(file, ext, _scope):
     logger.debug('Using icon "%s" for file %s (scope: %s)', icon, file, main_scope)
 
     return 'https://raw.githubusercontent.com/Snazzah/SublimeDiscordRP/master/icons/lang-%s.png' % icon
+
 
 def yield_subscopes(scope):
     last_dot = len(scope)
@@ -224,7 +226,10 @@ def handle_activity(view, is_write=False, idle=False):
     elif settings.get('small_icon'):
         act['assets']['small_image'] = icon
         act['assets']['small_text'] = language
-    act['timestamps'] = {'start': stamp}
+
+    if settings.get('show_elapsed_time'):
+        act['timestamps'] = {'start': stamp}
+
     logger.info(window.folders())
     try:
         ipc.set_activity(act)
@@ -366,6 +371,7 @@ class DRPListener(sublime_plugin.EventListener):
             if active_view: handle_activity(active_view)
             else: reset_activity()
         else: reset_activity()
+
 
 class DiscordrpConnectCommand(sublime_plugin.ApplicationCommand):
 

--- a/drp.py
+++ b/drp.py
@@ -319,7 +319,9 @@ def connect(silent=False, retry=True):
         return
 
     act = base_activity(True)
-    act['timestamps'] = {'start': start_time}
+    if settings.get('show_elapsed_time'):
+        act['timestamps'] = {'start': start_time}
+
     try:
         ipc.set_activity(act)
     except OSError as e:


### PR DESCRIPTION
Currently, it's impossible to disable the elapsed time. There is an issue (#72) date from Apr 24, 2021 opened about this problem but nothing as yet been done. I have decided to simply add a configuration to do just that. 

The config is a simple boolean called `show_elapsed_time` which has `true` has default value.