### PR TITLE
Add Git button to Discord RP

### DIFF
--- a/DiscordRichPresence.sublime-settings
+++ b/DiscordRichPresence.sublime-settings
@@ -41,6 +41,12 @@
     // Use the language icon as the big icon, overrides 'small_icon'
     "big_icon": true,
 
+    // Show button for opening git repository on browser
+    "git_repository_button": false,
+
+    // Default message for git repository button (supports format)
+    "git_repository_message": "Git Repository",
+
     // Defines the order of name sources that should be used for the project name in format stings, if available.
     //
     //   "project_file_name" - The name of the .sublime-project file.

--- a/drp.py
+++ b/drp.py
@@ -266,8 +266,10 @@ def handle_error(exc, retry=True):
 
 def get_git_url(window):
     for folder in window.folders():
-        f = open(folder+"/.git/config", "r")
-        if (f):
+        gitcfg_path = folder+"/.git/config"
+
+        if (os.path.exists(gitcfg_path)):
+            f = open(gitcfg_path, "r")
             filteredConfig = ''.join(f.read().split())
             ma = re.search("\[remote\"origin\"\]url=(.*)\.git", filteredConfig)
             if ma is None:


### PR DESCRIPTION
This adds a button to the rich presence for opening up the current repository URL. It reads the config and get the url from the remote origin, if none is found it will not display the button.

Added two new options to the settings:
```json
// Show button for opening git repository on browser
"git_repository_button": false,

// Default message for git repository button (supports format)
"git_repository_message": "Git Repository",
```