### PR TITLE
Use `on_activated_async` instead of `on_load_async`

### DIFF
--- a/drp.py
+++ b/drp.py
@@ -457,7 +457,7 @@ class DRPListener(sublime_plugin.EventListener):
                 logger.info("Setting presence to file %r from %r", view.file_name(), last_file)
                 handle_activity(view)
 
-    def on_load_async(self, view):
+    def on_activated_async(self, view):
         handle_activity(view)
 
     def on_close(self, view):


### PR DESCRIPTION
Switch to on activated. This is a more accurate way to update the discord presences. This ensures we only update when a file is receiving focus and not when its being previewed. Such as Go To Anything

Should fix #109 